### PR TITLE
Fix: Resolve deployment/runtime errors, update deps, improve build

### DIFF
--- a/app/components/canvas/ReactFlowWrapper.tsx
+++ b/app/components/canvas/ReactFlowWrapper.tsx
@@ -1,44 +1,56 @@
-import { useEffect, useState } from "react";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+} from "@xyflow/react";
 
 interface ReactFlowWrapperProps {
   children: (components: {
-    ReactFlow: any;
-    ReactFlowProvider: any;
-    Background: any;
-    Controls: any;
-    MiniMap: any;
-    useNodesState: any;
-    useEdgesState: any;
-    addEdge: any;
+    ReactFlow: typeof ReactFlow;
+    ReactFlowProvider: typeof ReactFlowProvider;
+    Background: typeof Background;
+    Controls: typeof Controls;
+    MiniMap: typeof MiniMap;
+    useNodesState: typeof useNodesState;
+    useEdgesState: typeof useEdgesState;
+    addEdge: typeof addEdge;
   }) => ReactNode;
 }
 
+// Define the components object statically
+// Types are inferred from the imports
+const flowComponents = {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+};
+
 export function ReactFlowWrapper({ children }: ReactFlowWrapperProps) {
-  const [components, setComponents] = useState<any>(null);
+  const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
-    // Only import ReactFlow on the client side
+    // Dynamically import CSS only on the client side
+    // and confirm client-side rendering
     if (typeof window !== "undefined") {
-      Promise.all([
-        import("@xyflow/react"),
-        import("@xyflow/react/dist/style.css"),
-      ]).then(([reactFlowModule]) => {
-        setComponents({
-          ReactFlow: reactFlowModule.ReactFlow,
-          ReactFlowProvider: reactFlowModule.ReactFlowProvider,
-          Background: reactFlowModule.Background,
-          Controls: reactFlowModule.Controls,
-          MiniMap: reactFlowModule.MiniMap,
-          useNodesState: reactFlowModule.useNodesState,
-          useEdgesState: reactFlowModule.useEdgesState,
-          addEdge: reactFlowModule.addEdge,
-        });
+      import("@xyflow/react/dist/style.css").then(() => {
+        setIsClient(true);
       });
     }
   }, []);
 
-  if (!components) {
+  if (!isClient) {
+    // Render nothing or a placeholder until client-side is confirmed and CSS is loaded
     return (
       <div className="flex h-[calc(100vh-var(--header-height))] items-center justify-center">
         <p className="text-muted-foreground">Loading canvas...</p>
@@ -46,5 +58,6 @@ export function ReactFlowWrapper({ children }: ReactFlowWrapperProps) {
     );
   }
 
-  return <>{children(components)}</>;
+  // Pass the statically imported components
+  return <>{children(flowComponents)}</>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.58.1",
         "react-markdown": "^10.1.0",
-        "react-router": "^7.6.2",
+        "react-router": "^7.6.3",
         "react-typed": "^2.0.12",
         "recharts": "^2.15.3",
         "sonner": "^2.0.3",
@@ -69,15 +69,15 @@
         "zod": "^3.25.67"
       },
       "devDependencies": {
-        "@react-router/dev": "^7.6.2",
-        "@tailwindcss/vite": "^4.1.4",
+        "@react-router/dev": "^7.6.3",
+        "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^20",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
-        "tailwindcss": "^4.1.4",
+        "tailwindcss": "^4.1.11",
         "tw-animate-css": "^1.3.2",
         "typescript": "^5.8.3",
-        "vite": "^6.3.3",
+        "vite": "^7.0.0",
         "vite-tsconfig-paths": "^5.1.4"
       }
     },
@@ -3726,9 +3726,9 @@
       "license": "MIT"
     },
     "node_modules/@react-router/dev": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.6.2.tgz",
-      "integrity": "sha512-BuG83Ug2C/P+zMYErTz/KKuXoxbOefh3oR66r13XWG9txwooC9nt2QDt2u8yt7Eo/9BATnx+TmXnOHEWqMyB8w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.6.3.tgz",
+      "integrity": "sha512-nnJQMVeE+LDViFTQDxeQV5FcfJ48a6aCScrFHwPHWgViQmiJxUBtDU1Pl7XZKEoTus5KDg/W3Vz2spiY6wXg3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -3740,14 +3740,13 @@
         "@babel/traverse": "^7.23.2",
         "@babel/types": "^7.22.5",
         "@npmcli/package-json": "^4.0.1",
-        "@react-router/node": "7.6.2",
+        "@react-router/node": "7.6.3",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
         "chokidar": "^4.0.0",
         "dedent": "^1.5.3",
         "es-module-lexer": "^1.3.1",
         "exit-hook": "2.2.1",
-        "fs-extra": "^10.0.0",
         "jsesc": "3.0.2",
         "lodash": "^4.17.21",
         "pathe": "^1.1.2",
@@ -3756,6 +3755,7 @@
         "react-refresh": "^0.14.0",
         "semver": "^7.3.7",
         "set-cookie-parser": "^2.6.0",
+        "tinyglobby": "^0.2.14",
         "valibot": "^0.41.0",
         "vite-node": "^3.1.4"
       },
@@ -3766,10 +3766,10 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.6.2",
-        "react-router": "^7.6.2",
+        "@react-router/serve": "^7.6.3",
+        "react-router": "^7.6.3",
         "typescript": "^5.1.0",
-        "vite": "^5.1.0 || ^6.0.0",
+        "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",
         "wrangler": "^3.28.2 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -3785,19 +3785,19 @@
       }
     },
     "node_modules/@react-router/express": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.6.2.tgz",
-      "integrity": "sha512-b1XwP2ZknWG6yNl1aEAJ+yx0Alk85+iLk5y521MOhh2lCKPNyFOuX4Gw8hI3E4IXgDEPqiZ+lipmrIb7XkLNZQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@react-router/express/-/express-7.6.3.tgz",
+      "integrity": "sha512-45wLv2pNVDfnd4mZXYaxbqGE2wOzisQQAXSCHrWhkUn9CvJkaqC9cx82rzfB1UnGvyeupZxGgLxaG0b38pTEOA==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/node": "7.6.2"
+        "@react-router/node": "7.6.3"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
         "express": "^4.17.1 || ^5",
-        "react-router": "7.6.2",
+        "react-router": "7.6.3",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3807,21 +3807,18 @@
       }
     },
     "node_modules/@react-router/node": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.6.2.tgz",
-      "integrity": "sha512-KrxfnfJVU1b+020VKemkxpc7ssItsAL8MOJthcoGwPyKwrgovdwc+8NKJUqw3P7yk/Si0ZmVh9QYAzi9qF96dg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.6.3.tgz",
+      "integrity": "sha512-CgqYAGjrfW/Al0LbWhQ60joDci5/H3ix4IU5UwlKLtqmNPzuSUTBkCrxit3jHuMYqaBaGfyRpT7kIeb1YZ4nqA==",
       "license": "MIT",
       "dependencies": {
-        "@mjackson/node-fetch-server": "^0.2.0",
-        "source-map-support": "^0.5.21",
-        "stream-slice": "^0.1.2",
-        "undici": "^6.19.2"
+        "@mjackson/node-fetch-server": "^0.2.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.6.2",
+        "react-router": "7.6.3",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3831,13 +3828,13 @@
       }
     },
     "node_modules/@react-router/serve": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.6.2.tgz",
-      "integrity": "sha512-VTdvB8kdZEtYeQML9TFJiIZnPefv94LfmLx5qQ0SJSesel/hQolnfpWEkLJ9WtBO+/10CulAvg6y5UwiceUFTQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.6.3.tgz",
+      "integrity": "sha512-SbIXApeaNPM9rCkrcFU+VXYXCIh332cT2L0ikykWBCe6O9ZGE6Y1q5ZQ8puEf5Pmqwm77kIRoY9rACUbnXzfxA==",
       "license": "MIT",
       "dependencies": {
-        "@react-router/express": "7.6.2",
-        "@react-router/node": "7.6.2",
+        "@react-router/express": "7.6.3",
+        "@react-router/node": "7.6.3",
         "compression": "^1.7.4",
         "express": "^4.19.2",
         "get-port": "5.1.1",
@@ -3851,7 +3848,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.6.2"
+        "react-router": "7.6.3"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -7312,20 +7309,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7498,6 +7481,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-symbols": {
@@ -7954,18 +7938,6 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jwt-decode": {
@@ -9823,9 +9795,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
-      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -10472,12 +10444,6 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "license": "MIT"
     },
-    "node_modules/stream-slice": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
-      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -10915,15 +10881,6 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
     },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -11016,15 +10973,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -11261,23 +11209,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.0.tgz",
+      "integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
+        "fdir": "^6.4.6",
         "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "postcss": "^8.5.6",
+        "rollup": "^4.40.0",
+        "tinyglobby": "^0.2.14"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -11286,14 +11234,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.58.1",
     "react-markdown": "^10.1.0",
-    "react-router": "^7.6.2",
+    "react-router": "^7.6.3",
     "react-typed": "^2.0.12",
     "recharts": "^2.15.3",
     "sonner": "^2.0.3",
@@ -72,15 +72,15 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
-    "@react-router/dev": "^7.6.2",
-    "@tailwindcss/vite": "^4.1.4",
+    "@react-router/dev": "^7.6.3",
+    "@tailwindcss/vite": "^4.1.11",
     "@types/node": "^20",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
-    "tailwindcss": "^4.1.4",
+    "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.2",
     "typescript": "^5.8.3",
-    "vite": "^6.3.3",
+    "vite": "^7.0.0",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
Resolved critical runtime errors:
- Fixed Clerk auth by setting correct Vercel env vars.
- Added `@emotion/is-prop-valid` to fix initial Vercel build warning.
- Added `vercel.json` to redirect `/favicon.ico` to `/ypai.png`.

Build process improvements:
- Resolved `@xyflow/react` dynamic import warning in Vite build.
- Updated Vite to v7.0.0.
- Updated React Router, Tailwind CSS and related plugins to latest patch versions.

Code quality and Coderabbit feedback:
- Removed duplicate viewport meta tag.
- Refactored unconventional hook usage in NavUser component.
- Removed various unused imports.
- Restored `.vercel/react-router-build-result.json` to original state.

Known Issue:
- Sourcemap generation errors persist in build logs for components using the `"use client"` directive. This appears to be an issue with the build toolchain's processing of these specific components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and simplified logic in the React Flow integration for the canvas by switching to static imports and refining client-side CSS handling.

* **Chores**
  * Updated several dependencies, including react-router, Tailwind CSS packages, and Vite, to their latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->