### PR TITLE
Feat: Integrate blog post preview into PreviewModal

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -3069,6 +3069,7 @@ function InnerCanvas({
           title={nodes.find((n: any) => n.type === 'agent' && n.data.type === 'title')?.data.draft || ''}
           description={nodes.find((n: any) => n.type === 'agent' && n.data.type === 'description')?.data.draft || ''}
           tweets={nodes.find((n: any) => n.type === 'agent' && n.data.type === 'tweets')?.data.draft || ''}
+          blogContent={nodes.find((n: any) => n.type === 'blog' || (n.type === 'agent' && n.data.type === 'blog'))?.data.draft || ''}
           thumbnailUrl={nodes.find((n: any) => n.type === 'agent' && n.data.type === 'thumbnail')?.data.thumbnailUrl}
           videoUrl={nodes.find((n: any) => n.type === 'video')?.data.videoUrl}
           duration={nodes.find((n: any) => n.type === 'video')?.data.duration}

--- a/app/components/preview/PreviewModal.tsx
+++ b/app/components/preview/PreviewModal.tsx
@@ -3,7 +3,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { Button } from "~/components/ui/button";
 import { YouTubePreview } from "./YouTubePreview";
 import { TwitterThreadPreview } from "./TwitterThreadPreview";
-import { Youtube, Twitter, Copy, Download, Eye, Sparkles, X, Check } from "lucide-react";
+import { BlogPostPreview } from "./BlogPostPreview"; // Added import
+import { Youtube, Twitter, Copy, Download, Eye, Sparkles, X, Check, FileText } from "lucide-react"; // Added FileText
 import { toast } from "sonner";
 import { useState } from "react";
 import { cn } from "~/lib/utils";
@@ -23,6 +24,7 @@ interface PreviewModalProps {
   username?: string;
   displayName?: string;
   profileImage?: string;
+  blogContent?: string; // Added blogContent prop
 }
 
 export function PreviewModal({
@@ -39,7 +41,8 @@ export function PreviewModal({
   subscriberCount,
   username,
   displayName,
-  profileImage
+  profileImage,
+  blogContent = "" // Added blogContent prop
 }: PreviewModalProps) {
   const [copiedYouTube, setCopiedYouTube] = useState(false);
   const [copiedTwitter, setCopiedTwitter] = useState(false);
@@ -97,7 +100,10 @@ export function PreviewModal({
         
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 relative">
           <div className="px-6 pt-4 pb-2 bg-background/50 backdrop-blur-sm">
-            <TabsList className="grid w-full max-w-md grid-cols-2 h-12 p-1 bg-muted/50">
+            <TabsList className={cn(
+              "grid w-full h-12 p-1 bg-muted/50",
+              blogContent ? "max-w-lg grid-cols-3" : "max-w-md grid-cols-2" // Adjust grid based on blogContent
+            )}>
               <TabsTrigger 
                 value="youtube" 
                 className={cn(
@@ -118,6 +124,18 @@ export function PreviewModal({
                 <Twitter className="h-4 w-4" />
                 Twitter/X
               </TabsTrigger>
+              {blogContent && (
+                <TabsTrigger
+                  value="blog"
+                  className={cn(
+                    "gap-2 data-[state=active]:shadow-sm transition-all",
+                    "data-[state=active]:bg-background data-[state=active]:text-foreground"
+                  )}
+                >
+                  <FileText className="h-4 w-4" />
+                  Blog
+                </TabsTrigger>
+              )}
             </TabsList>
           </div>
           
@@ -200,6 +218,20 @@ export function PreviewModal({
                 </div>
               </div>
             </TabsContent>
+
+            {blogContent && (
+              <TabsContent value="blog" className="p-6 pt-4 m-0">
+                <div className="space-y-6">
+                  {/* Preview container with background */}
+                  <div className="relative rounded-xl bg-gradient-to-br from-background to-muted/30 p-6 shadow-inner">
+                    <div className="absolute inset-0 bg-grid-white/5 rounded-xl pointer-events-none" />
+                    <div className="relative">
+                      <BlogPostPreview content={blogContent} />
+                    </div>
+                  </div>
+                </div>
+              </TabsContent>
+            )}
           </div>
         
         </Tabs>


### PR DESCRIPTION
- Updated `PreviewModal.tsx` to accept `blogContent` prop.
- Added a new 'Blog' tab to `PreviewModal` that conditionally renders the `BlogPostPreview` component based on `blogContent`.
- Modified `Canvas.tsx` to pass the generated blog content (from the relevant node's draft) to the `PreviewModal`.

This completes the frontend integration for the blog preview feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for previewing blog content in the preview modal with a new "Blog" tab, available when blog content is present.
  * The preview modal now dynamically adjusts its layout to accommodate the new blog preview tab.

* **Enhancements**
  * Improved the preview modal interface to seamlessly integrate blog content alongside existing content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->