### PR TITLE
Refactor: Remove outdated frontend agent type validation

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -2052,10 +2052,14 @@ function InnerCanvas({
         // For now, we find the first video if it exists for backward compatibility.
         const videoSourceForAgent = nodes.find((n: any) => n.type === 'video');
 
+        // The outdated validation block that was here has been removed:
+        // if (!videoSourceForAgent?.data.videoId && type !== 'blog' && type !== 'linkedin') { ... }
+
         createAgent({
-            videoId: videoSourceForAgent?.data.videoId as Id<"videos"> | undefined, // Pass undefined if no video
-            type: type as any, // Cast as any to allow all our new agent types
-            canvasPosition: findNonOverlappingPosition(position, type), // Use findNonOverlappingPosition here too
+            videoId: videoSourceForAgent?.data.videoId as Id<"videos"> | undefined,
+            // projectId will be passed here in a future change if videoId is undefined
+            type: type as any,
+            canvasPosition: findNonOverlappingPosition(position, type),
         }).then((agentId) => {
             const nodeType = type === 'linkedin' ? 'linkedin' : type === 'blog' ? 'blog' : 'agent';
             const newNodeId = `${type}_${agentId}`; // Consistent ID generation


### PR DESCRIPTION
Removes a conditional block in `app/components/canvas/Canvas.tsx` that arbitrarily restricted agent creation for non-video sources.

Agent creation now fully relies on backend validation, which requires either a `videoId` or an explicit `projectId` to ensure agents are always associated with a project. The frontend error handling for `createAgent` has been previously updated to reflect this.